### PR TITLE
fix: fetch game cover url from Steam API

### DIFF
--- a/server/core/request/steamApi.ts
+++ b/server/core/request/steamApi.ts
@@ -1,5 +1,6 @@
 import type {
   BaseResponse,
+  GameDetailsResponse,
   OwnedGames,
   OwnedParams,
   PlayedGames,
@@ -40,4 +41,18 @@ export function getSteamProfile(steamid: string) {
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36',
     },
   })
+}
+
+export function getGameDetails(id: string | number) {
+  return $fetch<GameDetailsResponse>(`https://store.steampowered.com/api/appdetails?appids=${id}`)
+}
+
+export async function getGameCoverUrl(id: string | number) {
+  const gameDetail = await getGameDetails(id)
+  const detail = gameDetail[id.toString()]
+  if (!detail?.success || !detail.data?.header_image) {
+    console.warn(`Failed to get cover for appid ${id}`)
+    return null
+  }
+  return detail.data.header_image
 }

--- a/server/routes/card/[...].ts
+++ b/server/routes/card/[...].ts
@@ -1,10 +1,9 @@
-import { getPlayerSummaries, getRecentlyPlayedGames, getSteamProfile } from 'server/core/request/steamApi'
+import { getGameCoverUrl, getPlayerSummaries, getRecentlyPlayedGames, getSteamProfile } from 'server/core/request/steamApi'
 import { crawler, data, parseUrlConfig } from 'server/core/logic'
 import initLocale from 'server/core/locales'
 import type { Count } from 'types'
 import { imageUrl2Base64, transparentImageBase64 } from 'server/core/utils'
 import { generateError } from '~/server/core/render/template/error'
-import { getGameCoverUrl } from '@/utils/common'
 import { generateSvg } from '~/server/core/render/template/svg'
 
 const i18n = initLocale('zhCN')
@@ -79,9 +78,16 @@ export default defineEventHandler(async (event) => {
     const gameImgs = []
 
     for (let i = 0; i < games.length; i++) {
-      const url = getGameCoverUrl(games[i].appid)
-      gameImgs[i] = await imageUrl2Base64(url)
-      gameImgs[i] = gameImgs[i] ? JPEG_PREFIX + gameImgs[i] : transparentImageBase64
+      const url = await getGameCoverUrl(games[i].appid)
+      if (url) {
+        gameImgs[i] = await imageUrl2Base64(url)
+        gameImgs[i] = gameImgs[i]
+          ? JPEG_PREFIX + gameImgs[i]
+          : transparentImageBase64
+      }
+      else {
+        gameImgs[i] = transparentImageBase64
+      }
     }
 
     const counts: Count[] = []
@@ -135,18 +141,21 @@ export default defineEventHandler(async (event) => {
 
     if (config.bg.includes('bg-game')) {
       const arrs = config.bg.split('-')
-      let url = ''
+      let url: string | null = null
       if (arrs.length < 3) {
         const { appid } = await $fetch<{
           appid: number
         }>(`/info/games/${steamid}`)
-        url = getGameCoverUrl(appid!)
+        url = await getGameCoverUrl(appid!)
       }
       else {
-        url = getGameCoverUrl(arrs[2])
+        url = await getGameCoverUrl(arrs[2])
       }
-      let gameBase64 = await imageUrl2Base64(url)
-      gameBase64 = JPEG_PREFIX + gameBase64
+      let gameBase64 = transparentImageBase64
+      if (url) {
+        gameBase64 = await imageUrl2Base64(url)
+        gameBase64 = gameBase64 ? JPEG_PREFIX + gameBase64 : transparentImageBase64
+      }
       config.bg = `game-${gameBase64}`
     }
 

--- a/types/response.ts
+++ b/types/response.ts
@@ -36,3 +36,15 @@ export interface OwnedGames {
     playtime_forever: number
   }[]
 }
+
+export interface GameDetailsResponse {
+  [appId: string]: {
+    success: boolean
+    data: {
+      // name: string
+      // type: string
+      // is_free: boolean
+      header_image: string
+    }
+  }
+}

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,3 +1,0 @@
-export function getGameCoverUrl(id: string | number) {
-  return `https://steamcdn-a.akamaihd.net/steam/apps/${id}/header.jpg`
-}


### PR DESCRIPTION
原有封面URL `https://media.steampowered.com/steam/apps/{ID}/header.jpg`对部分游戏（部分免费游戏，如4122860，4641700）会返回404错误，无法正确获取封面
<img width="553" height="215" alt="image" src="https://github.com/user-attachments/assets/28d36be9-d02c-4a76-99f6-e310241ee898" />
本PR改用SteamAPI获取封面URL

<img width="553" height="215" alt="image" src="https://github.com/user-attachments/assets/a7405974-f750-4f9c-90ea-eca716ed3aee" />